### PR TITLE
Add dpctl to project list.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1990,6 +1990,18 @@
         "url": "https://github.com/menotti"
       },
       "type": "unspecified"
+    },
+    {
+      "name": "Data Parallel Control",
+      "date_created": "2020-08-27",
+      "url": "https://github.com/IntelPython/dpctl",
+      "short_description": "Python SYCL bindings and SYCL-based Python Array API library .",
+      "owner": {
+        "name": "Intel",
+        "url": "https://github.com/IntelPython"
+      },
+      "type": "library",
+      "licence": "Apache 2.0"
     }
   ]
 }


### PR DESCRIPTION
Adds the https://github.com/IntelPython/dpctl repo to the SYCL projects list.

Dpctl is a Python library providing Python bindings to SYCL and a SYCL-based Python Array API implementation (details: https://dl.acm.org/doi/10.1145/3529538.3529990)